### PR TITLE
Add test matrix for multiple python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,18 +1,28 @@
 name: Dronefly
 
-on: [push]
+on: 
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # TODO: Support for 3.9+
+        # python-version: [3.8, 3.9, 3.10.0-beta.2]
+        python-version: [3.8]
+      fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+          python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -21,4 +31,3 @@ jobs:
       run: |
         pip install pytest
         pytest
-


### PR DESCRIPTION
This may or may not work as-is with ~~python 3.7 or~~ 3.10, but it would be good to know, at least.